### PR TITLE
feature(ui): don't escape HTML in messages

### DIFF
--- a/views/default/live_chat/message.html
+++ b/views/default/live_chat/message.html
@@ -7,6 +7,6 @@
 		</div>
 	</div>
 	<div class="elgg-body">
-		<div class="elgg-content">{{message}}</div>
+		<div class="elgg-content">{{&message}}</div>
 	</div>
 </div>


### PR DESCRIPTION
key feature is that messages sent from chat page (ckeditor) don't include surrounding `<p>` tags, etc.
